### PR TITLE
Fix SonarCloud Github actions

### DIFF
--- a/.github/workflows/sonarcloud-analysis.yml
+++ b/.github/workflows/sonarcloud-analysis.yml
@@ -3,7 +3,10 @@ on:
   push:
     branches:
       - main
+      - develop
   pull_request:
+    branches:
+      - main
     types: [opened, synchronize, reopened]
 jobs:
   analyze:


### PR DESCRIPTION
SonarCloud action will not longer run on PRs into the develop branch - which will always error due to forked PRs not have access to GitHub Secrets.