### PR TITLE
Add access_token variable to postman collection

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,6 +13,7 @@ on:
       - '.github/pull_request_template.md'
       - '.github/stale.yml'
       - 'LICENSE'
+      - 'Postman/**'
   pull_request:
     branches: [main, develop]
     types: [opened, synchronize, reopened]
@@ -24,6 +25,7 @@ on:
       - '.github/pull_request_template.md'
       - '.github/stale.yml'
       - 'LICENSE'
+      - 'Postman/**'
 
 env:
   DOCKER_IMAGE: consumerdataright/mock-register

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -11,6 +11,7 @@ on:
       - '.github/pull_request_template.md'
       - '.github/stale.yml'
       - 'LICENSE'
+      - 'Postman/**'
   pull_request:
     branches: [ main, develop ]
     types: [opened, synchronize, reopened]
@@ -22,6 +23,7 @@ on:
       - '.github/pull_request_template.md'
       - '.github/stale.yml'
       - 'LICENSE'
+      - 'Postman/**'
     
 env:
   buildConfiguration: 'Release'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+ - `access_token` variable within the Postman collection, to make calling requests that need it easier.
+
+
 ## [0.2.0] - 2021-07-15
 
 ### Added

--- a/Postman/mock-register.postman_collection.json
+++ b/Postman/mock-register.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "68940bc8-717c-425a-b52b-52e63f1e7329",
+		"_postman_id": "efa6a08a-27f5-4340-998d-0ddeb6d0b27d",
 		"name": "CDR Mock Register",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -13,7 +13,7 @@
 					"bearer": [
 						{
 							"key": "token",
-							"value": "eyJhbGciOiJQUzI1NiIsImtpZCI6IkFBMjRGMTg1RUUzRjY3NTA0ODA4RkM0RTI2QjEzNUI5OUU2M0JEQTkiLCJ0eXAiOiJhdCtqd3QiLCJ4NXQiOiJxaVR4aGU0X1oxQklDUHhPSnJFMXVaNWp2YWsifQ.eyJuYmYiOjE2MjA1Njk3MDksImV4cCI6MTYyMDU3MDAwOSwiaXNzIjoiaHR0cHM6Ly9sb2NhbGhvc3Q6NzAwMC9pZHAiLCJhdWQiOiJjZHItcmVnaXN0ZXIiLCJjbGllbnRfaWQiOiI2ZjdhMWI4ZS04Nzk5LTQ4YTgtOTAxMS1lMzkyMDM5MWY3MTMiLCJqdGkiOiJFMTk1OUY4RTZFMkJDQ0QyQTY1NEUzQjc0NTA5MEFCNSIsImlhdCI6MTYyMDU2OTcwOSwic2NvcGUiOlsiY2RyLXJlZ2lzdGVyOmJhbms6cmVhZCJdLCJjbmYiOnsieDV0I1MyNTYiOiI1OEQ3NkY3QTYxQ0Q3MjZEQTFDNTRGNjg5OEU4RTY5RUE0Qzg4MDYwIn19.T0roQ6RNw5DgSC4cu9-LrTYk40ATWKAcwSnhXQTbntyH8PyLG7xLv6QO0fssqeoTyYo9-Rz-1dYIwHbIWyKs01IOI84m5UlKD6NzOS9Ul10NrWtaz_Jr0SYVp4YeUDNyrfANfyaCyWWeF--jkTU9LpAsTuc-TGbmVN5DNZOEfnu0rZMUs2st07R-oUUKw29SSjoqoOhwteY8q06JKmp-KE4R8aRIq24hMYMFeqjtpF58ppmQ_V-s6VkxtpMgRiv11H8jksRjcUnSrBH1SBMX3bZVr9c1TYA7oW2zc5_Yl9G1gfpi4WRCZkKZMTj9LiAeSdLYi39tCcvDUtIgKnTw2w",
+							"value": "{{access_token}}",
 							"type": "string"
 						}
 					]
@@ -230,6 +230,21 @@
 						],
 						"type": "text/javascript"
 					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Body matches string\", () => {\r",
+							"    pm.expect(pm.response.text()).to.include(\"access_token\");\r",
+							"});\r",
+							"\r",
+							"var body = JSON.parse(responseBody);\r",
+							"pm.globals.set(\"access_token\", body.access_token);\r",
+							""
+						],
+						"type": "text/javascript"
+					}
 				}
 			],
 			"protocolProfileBehavior": {
@@ -324,7 +339,7 @@
 					"bearer": [
 						{
 							"key": "token",
-							"value": "eyJhbGciOiJQUzI1NiIsImtpZCI6IkFBMjRGMTg1RUUzRjY3NTA0ODA4RkM0RTI2QjEzNUI5OUU2M0JEQTkiLCJ0eXAiOiJhdCtqd3QiLCJ4NXQiOiJxaVR4aGU0X1oxQklDUHhPSnJFMXVaNWp2YWsifQ.eyJuYmYiOjE2MjA1Njk3MDksImV4cCI6MTYyMDU3MDAwOSwiaXNzIjoiaHR0cHM6Ly9sb2NhbGhvc3Q6NzAwMC9pZHAiLCJhdWQiOiJjZHItcmVnaXN0ZXIiLCJjbGllbnRfaWQiOiI2ZjdhMWI4ZS04Nzk5LTQ4YTgtOTAxMS1lMzkyMDM5MWY3MTMiLCJqdGkiOiJFMTk1OUY4RTZFMkJDQ0QyQTY1NEUzQjc0NTA5MEFCNSIsImlhdCI6MTYyMDU2OTcwOSwic2NvcGUiOlsiY2RyLXJlZ2lzdGVyOmJhbms6cmVhZCJdLCJjbmYiOnsieDV0I1MyNTYiOiI1OEQ3NkY3QTYxQ0Q3MjZEQTFDNTRGNjg5OEU4RTY5RUE0Qzg4MDYwIn19.T0roQ6RNw5DgSC4cu9-LrTYk40ATWKAcwSnhXQTbntyH8PyLG7xLv6QO0fssqeoTyYo9-Rz-1dYIwHbIWyKs01IOI84m5UlKD6NzOS9Ul10NrWtaz_Jr0SYVp4YeUDNyrfANfyaCyWWeF--jkTU9LpAsTuc-TGbmVN5DNZOEfnu0rZMUs2st07R-oUUKw29SSjoqoOhwteY8q06JKmp-KE4R8aRIq24hMYMFeqjtpF58ppmQ_V-s6VkxtpMgRiv11H8jksRjcUnSrBH1SBMX3bZVr9c1TYA7oW2zc5_Yl9G1gfpi4WRCZkKZMTj9LiAeSdLYi39tCcvDUtIgKnTw2w",
+							"value": "{{access_token}}",
 							"type": "string"
 						}
 					]


### PR DESCRIPTION
**Checklist:** (Put an `x` in all the boxes that apply)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have checked that there aren't any other open **Pull Requests** from the same change.
- [x] The `develop` branch has been set as the `base` branch to merge changes of the pull request.
- [x] I have updated the `CHANGELOG.md` file as appropriate.

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adding new feature, postman collection will now store a global `access_token` variable once the `InfoSec - Get Access Token` request is called.

**What is the current behavior?** (You can also link to an open issue here)
To call `Discovery API - Get Data Holder Brands (requires access token)` and `SSA API - Get SSA (requires access token)` you need to manually copy and paste the `access_token` from the `InfoSec - Get Access Token` request.


**What is the new behavior?** (if this is a feature change)
Once `InfoSec - Get Access Token` is called, postman will save a global `access_token` variable which will be automatically used within `SSA API - Get SSA (requires access token)` and `Discovery API - Get Data Holder Brands (requires access token)`


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


**Other information**:
