### PR TITLE
Add Custom Scopes to Get SSA API

### DIFF
--- a/Source/CDR.Register.SSA.API/Business/SSAService.cs
+++ b/Source/CDR.Register.SSA.API/Business/SSAService.cs
@@ -163,6 +163,8 @@ namespace CDR.Register.SSA.API.Business
                 "common:customer.basic:read",
                 "common:customer.detail:read",
                 "cdr:registration",
+                "introspect_tokens",
+                "revoke_tokens",
             };
 
             // Filter the provided list of scopes with the allowed scopes.


### PR DESCRIPTION
During DCR flow we want to allow the client to be registered with `introspect_tokens` and `revoke_tokens` scope. This PR adjusts calls to v1 and v2 versions of the Get SSA API to not filter these out when creating the SSA used for registration.
